### PR TITLE
Add extension version to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,6 +31,7 @@ If applicable, add screenshots to help explain your problem.
 - DDEV version: run in terminal ddev --version
 - Docker provider: [e.g. Docker Desktop, Orbstack, Colima, etc]
 - VSCode version:
+- DDEV Manager version:
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ If applicable, add screenshots to help explain your problem.
 - DDEV version: run in terminal ddev --version
 - Docker provider: [e.g. Docker Desktop, Orbstack, Colima, etc]
 - VSCode version:
-- DDEV Manager version:
+- DDEV Manager version: [VSCode extension version; see extension page]
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
This PR adds a place in the bug template to record the DDEV manager version.

This should help with debugging issues.